### PR TITLE
Unittests, poetry coercion and commit msg check

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = 
+known_third_party = pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,10 @@ repos:
             require_serial: true
             always_run: True
             pass_filenames: false
+          # matches conventional commit messages
+          # https://www.conventionalcommits.org/en/v1.0.0/#summary
+          - id: verify-commit-msg
+            name: Conventional commit message prefix
+            entry: commit-msg.sh
+            language: script
+            stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
 repos:
     - repo: https://github.com/asottile/seed-isort-config
       rev: v2.2.0
@@ -39,3 +41,14 @@ repos:
       rev: 0.2.2 # or specific tag
       hooks:
           - id: yamlfmt
+    - repo: local
+      hooks:
+          # run your unittests
+          - id: unittests
+            name: unittests
+            entry: pytest -m "not slow" .
+            language: system
+            types: [python]
+            require_serial: true
+            always_run: True
+            pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,8 +54,9 @@ repos:
             pass_filenames: false
           # matches conventional commit messages
           # https://www.conventionalcommits.org/en/v1.0.0/#summary
+          # requires pre-commit install --hook-type commit-msg
           - id: verify-commit-msg
             name: Conventional commit message prefix
             entry: commit-msg.sh
             language: script
-            stages: [commit-msg]
+            stages: [commit-msg] 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ the python version, pinning transitive dependencies or creating a file so all de
     
 ## Set up 
 
-- (optional): install pyenv to confortably switch between python versions and install a recent python version
+- (optional): install [pyenv](https://github.com/pyenv/pyenv#installation) to comfortably switch between python versions and install a recent python version
 - activate the installed python version with `$ pyenv local *python_version*` or use the already present python version
 - define the python version in pyproject.toml and in .github/workflows/pytest.yaml and the .pre-commit-config.yaml
 - update the project name in pyproject.toml
+- (optional): point poetry to your pyenv python version `$ poetry env use ~/.pyenv/versions/*python_version*/bin/python`
 - install dependencies with `poetry install`. Commit the file poetry.lock that contains the installed dependencies.
 - activate the environment with `poetry shell` and run `pre-commit install` to set up the git hook scripts in the .git directory 
   of your project

--- a/commit-msg.sh
+++ b/commit-msg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# https://www.conventionalcommits.org/en/v1.0.0/#summary
+MSG="$1"
+PATTERN="^(fix|feat|docs|BREAKING CHANGES):"
+if ! grep -qE "$PATTERN" "$MSG";then
+    cat "$MSG"
+    echo "Your commit message start must match $PATTERN"
+    exit 1
+fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = test_*.py
+markers =
+    slow: mark test as slow

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,0 +1,9 @@
+import pytest
+import time
+
+def test_fast():
+    pass
+
+@pytest.mark.slow
+def test_slow():
+    time.sleep(5)


### PR DESCRIPTION
# Changes

1. Added unit tests to run for a commit. I find this helpful if they in total take only a few seconds (e.g. with dummy data / mocks), to indicate if recent changes broke something.
2. Added `poetry env use` command to readme. Find it helpful to stay sane dealing with python versions.
3. Added commit message check for the conventional [feat/docs/fix format](https://www.conventionalcommits.org/en/v1.0.0/#summary).
